### PR TITLE
Fix struct recognition

### DIFF
--- a/xml-rpc-test.el
+++ b/xml-rpc-test.el
@@ -1,0 +1,10 @@
+(require 'ert)
+
+(load-file "xml-rpc.el")
+
+(ert-deftest test-xml-rpc-value-structp ()
+  "Test whether xml-rpc-value-structp operates correctly"
+  (should (eq (xml-rpc-value-structp ()) t))
+  (should (eq (xml-rpc-value-structp '(("foo"))) t))
+  (should (eq (xml-rpc-value-structp '(("foo" . "bar"))) t))
+  (should (eq (xml-rpc-value-structp '(("foo" :datetime (12345 12345)))) t)))

--- a/xml-rpc.el
+++ b/xml-rpc.el
@@ -252,6 +252,20 @@ Set it higher to get some info in the *Messages* buffer"
   "A list of extra headers to send with the next request.
 Should be an assoc list of headers/contents.  See `url-request-extra-headers'")
 
+(defsubst xml-rpc-valuep (value)
+  "Return t if VALUE is any sort of xml-rpc structure.
+
+Return nil otherwise."
+  (or (xml-rpc-value-intp value)
+      (xml-rpc-value-doublep value)
+      (xml-rpc-value-stringp value)
+      (xml-rpc-value-structp value)
+      (xml-rpc-value-arrayp value)
+      (xml-rpc-value-vectorp value)
+      (xml-rpc-value-booleanp value)
+      (xml-rpc-value-datetimep value)
+      (xml-rpc-value-base64p value)))
+
 ;;
 ;; Value type handling functions
 ;;
@@ -281,7 +295,7 @@ Should be an assoc list of headers/contents.  See `url-request-extra-headers'")
                          (setq curval (car-safe vals))
                          (consp curval)
                          (stringp (car-safe curval))
-                         (not (listp (cdr curval)))))
+                         (xml-rpc-valuep (cdr curval))))
            (setq vals (cdr-safe vals)))
          result)))
 


### PR DESCRIPTION
Change aa0953b2d4ef1b983bc54357b56af63cab4309b9 broke recognition of any structure that had any values that were anything other than simple scalars---which is to say, any nested structures, arrays, dates.  This is demonstrated by the xml-rpc-test.el introduced with this change---when run with the old code, it fails.

To correct this issue this change introduces `xml-rpc-valuep`, which will handle checking non-scalar values correctly.  It also includes the aforementioned xml-rpc-test.el, which can serve as something of a starting point for testing xml-rpc's functionality.