### PR TITLE
Emacs 25's url-http library adds a payload size test

### DIFF
--- a/xml-rpc.el
+++ b/xml-rpc.el
@@ -574,10 +574,9 @@ or nil if called with ASYNC-CALLBACK-FUNCTION."
                                         " encoding=\"UTF-8\"?>\n"
                                         (with-temp-buffer
                                           (xml-print xml)
-                                          (when xml-rpc-allow-unicode-string
-                                            (encode-coding-region
-                                             (point-min) (point-max) 'utf-8))
-                                          (buffer-string))
+                                          (if xml-rpc-allow-unicode-string
+                                              (encode-coding-string (buffer-string) 'utf-8)
+                                            (buffer-string)))
                                         "\n"))
               (url-mime-charset-string "utf-8;q=1, iso-8859-1;q=0.5")
               (url-request-coding-system xml-rpc-use-coding-system)


### PR DESCRIPTION
Emacs 25's url-http library adds a payload size test expecting unibyte characters

https://debbugs.gnu.org/cgi/bugreport.cgi?bug=23750

in `url-http-create-request' verifying that the character length and byte
length of the request are the same:

```
;; Bug#23750
(unless (= (string-bytes request)
           (length request))
  (error "Multibyte text in HTTP request: %s" request))
```

In Emacs 24's url-http library the conversion to unibyte characters worked correctly with
`encode-coding-region' but it broke in Emacs 25. The change is attached for
Emacs 25's version using `encode-coding-string'.

We ran into this issue attempting to post Unicode characters in blog posts
using org2blog:

https://github.com/org2blog/org2blog/issues/225

org2blog uses metaweblog which uses xml-rpc and that is where
`url-http-create-request' threw its warning error.