### PR TITLE
Return a unibyte string so that url.el doesn't think it's the wrong length

### DIFF
--- a/xml-rpc.el
+++ b/xml-rpc.el
@@ -570,15 +570,16 @@ or nil if called with ASYNC-CALLBACK-FUNCTION."
         (let ((url-request-method "POST")
               (url-package-name "xml-rpc.el")
               (url-package-version xml-rpc-version)
-              (url-request-data (concat "<?xml version=\"1.0\""
-                                        " encoding=\"UTF-8\"?>\n"
-                                        (with-temp-buffer
-                                          (xml-print xml)
-                                          (when xml-rpc-allow-unicode-string
-                                            (encode-coding-region
-                                             (point-min) (point-max) 'utf-8))
-                                          (buffer-string))
-                                        "\n"))
+              (url-request-data
+	       (concat "<?xml version=\"1.0\""
+                       " encoding=\"UTF-8\"?>\n"
+                       (with-temp-buffer
+                         (xml-print xml)
+                         (if xml-rpc-allow-unicode-string
+                             (string-as-unibyte
+			      (encode-coding-string (buffer-string) 'utf-8))
+                           (buffer-string)))
+                       "\n"))
               (url-mime-charset-string "utf-8;q=1, iso-8859-1;q=0.5")
               (url-request-coding-system xml-rpc-use-coding-system)
               (url-http-attempt-keepalives t)


### PR DESCRIPTION
Otherwise Emacsen after 25.0 won't be able to handle utf-8 data.